### PR TITLE
Maximum Scrollback History Setting

### DIFF
--- a/Terminus.sublime-settings
+++ b/Terminus.sublime-settings
@@ -58,6 +58,9 @@
     // the default LANG variable of unix system.
     "unix_lang": "en_US.UTF-8",
 
+    // number of lines kept in scrollback history
+    // decreasing this value may improve performance
+    "scrollback_history_size": 10000,
 
     // Windows and Linux only
     // use ctrl+c to copy

--- a/terminus/view.py
+++ b/terminus/view.py
@@ -212,11 +212,13 @@ class TerminusRenderCommand(sublime_plugin.TextCommand, TerminusViewMixinx):
             if not trailing_region.empty() and len(view.substr(trailing_region).strip()) == 0:
                 view.erase(edit, trailing_region)
 
-    def trim_history(self, edit, terminal, n=10000):
+    def trim_history(self, edit, terminal):
         """
         If number of lines in view > n, remove n / 10 lines from the top
         """
         view = self.view
+        n = sublime.load_settings("Terminus.sublime-settings") \
+                   .get("scrollback_history_size")
         screen = terminal.screen
         lastrow = view.rowcol(view.size())[0]
         if lastrow + 1 > n:

--- a/terminus/view.py
+++ b/terminus/view.py
@@ -1,6 +1,7 @@
 import sublime
 import sublime_plugin
 
+import math
 import time
 import logging
 
@@ -211,15 +212,15 @@ class TerminusRenderCommand(sublime_plugin.TextCommand, TerminusViewMixinx):
             if not trailing_region.empty() and len(view.substr(trailing_region).strip()) == 0:
                 view.erase(edit, trailing_region)
 
-    def trim_history(self, edit, terminal, n=10000, m=1000):
+    def trim_history(self, edit, terminal, n=10000):
         """
-        If number of lines in view > n, remove m lines from the top
+        If number of lines in view > n, remove n / 10 lines from the top
         """
         view = self.view
         screen = terminal.screen
         lastrow = view.rowcol(view.size())[0]
         if lastrow + 1 > n:
-            m = max(lastrow + 1 - n, m)
+            m = max(lastrow + 1 - n, math.ceil(n / 10))
             logger.debug("removing {} lines from the top".format(m))
             top_region = sublime.Region(0, view.line(view.text_point(m - 1, 0)).end() + 1)
             view.erase(edit, top_region)


### PR DESCRIPTION
This allows changing the history size.

`trim_history`'s method signature has changed and no longer accepts `n` (maximum buffer size) and `m` (number of lines to be trimmed) as parameters.

`m` is now 1/10th of `n` rounded up, so it's always greater than 0.

Requested in #53 and #25.