### PR TITLE
Added detection of paste_and_indent for pasting into terminal.

### DIFF
--- a/terminus/commands.py
+++ b/terminus/commands.py
@@ -63,6 +63,8 @@ class TerminusCommandsEventListener(sublime_plugin.EventListener):
             return ("terminus_copy", None)
         elif name == "paste":
             return ("terminus_paste", None)
+        elif name == "paste_and_indent":
+            return ("terminus_paste", None)
         elif name == "paste_from_history":
             return ("terminus_paste_from_history", None)
         elif name == "undo":


### PR DESCRIPTION
One of those incredibly useful / I didn't know about that things in Sublime is swapping `paste` and  `paste_and_indent` in your `.sublime-keymap` file. 

````
...
 {
            "keys": ["super+v"],
            "command": "paste_and_indent"
        },
        {
            "keys": ["super+shift+v"],
            "command": "paste"
        },
...
````

However Terminus doesn't recognise the `paste_and_indent` command. This means you have to remember a different key combination `super+shift+v` to past text into the Terminus Window. Which is very annoying.

As `paste_and_indent` only has meaning in a text editor, not in a Terminus window `paste` and `paste_and_indent` can behave exactly the same in Terminus. 

This change just detects the `paste_and_indent` message and treats it just as if it was a standard `paste`. And the world is all good again.