### PR TITLE
terminal.title should contains both screen.title and terminal.default_title

### DIFF
--- a/terminus/view.py
+++ b/terminus/view.py
@@ -127,7 +127,7 @@ class TerminusRenderCommand(sublime_plugin.TextCommand, TerminusViewMixinx):
             view.run_command("terminus_show_cursor")
         if screen.title != terminal.title:
             if screen.title:
-                terminal.title = screen.title
+                terminal.title = screen.title + terminal.default_title
             else:
                 terminal.title = terminal.default_title
         screen.dirty.clear()


### PR DESCRIPTION
If I use Administrator to open sublime text 3 with Terminus, 
```python
screen.title = "Administrator: "
terminal.default_title = "Power Shell"
```
So I think terminal.title should ` Administrator: Power Shell`.
