### PR TITLE
Rename Terminal View

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -33,6 +33,10 @@
         "command": "terminus_reset"
     },
     {
+        "caption": "Terminus: Rename Terminal View",
+        "command": "terminus_rename_terminal_view"
+    },
+    {
         "caption": "Terminus: Close",
         "command": "terminus_close"
     },

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from .terminus.core import (
     TerminusInitializeCommand,
     TerminusActivateCommand,
     TerminusResetCommand,
+    TerminusRenameTerminalViewCommand,
     TerminusMaximizeCommand,
     TerminusMinimizeCommand,
     TerminusRenderCommand,

--- a/terminus/core.py
+++ b/terminus/core.py
@@ -660,6 +660,22 @@ class TerminusResetCommand(sublime_plugin.TextCommand):
         sublime.set_timeout_async(run_detach)
 
 
+class TerminusRenameTerminalViewCommand(sublime_plugin.TextCommand):
+
+    def run(self, _, **kwargs):
+        view = self.view
+        terminal = Terminal.from_id(view.id())
+
+        terminal.default_title = kwargs["text"]
+        view.run_command("terminus_render")
+
+    def input(self, _):
+        return sublime_plugin.TextInputHandler()
+
+    def is_visible(self):
+        return bool(Terminal.from_id(self.view.id()))
+
+
 class TerminusMaximizeCommand(sublime_plugin.TextCommand):
 
     def is_enabled(self):

--- a/terminus/terminal.py
+++ b/terminus/terminal.py
@@ -204,7 +204,7 @@ class Terminal:
         self.timeit = timeit
         if timeit:
             self.start_time = time.time()
-        self.default_title = title
+        self.default_title = view.name() if view.name() else title
 
         if view:
             self.title = title


### PR DESCRIPTION
- New command to rename currently open Terminus View
- ~New command to restore the default name of currently open Terminus View~ this was messy and didn't bring much value
- Check to restore custom Terminus View name when Sublime Text is restarted

Should resolve #145.