### PR TITLE
Add Campbell and Brackets themes

### DIFF
--- a/themes/brackets-dark.json
+++ b/themes/brackets-dark.json
@@ -1,0 +1,23 @@
+{
+    "name": "Brackets Dark",
+    "theme_colors": {
+        "foreground": "#dddddd",
+        "background": "#1d1f21",
+        "black": "#000000",
+        "red": "#dc322f",
+        "green": "#229922",
+        "brown": "#d89333",
+        "blue": "#6c9ef8",
+        "magenta": "#8087e5",
+        "cyan": "#6c9ef8",
+        "white": "#ffffff",
+        "light_black": "#767676",
+        "light_red": "#dd4444",
+        "light_green": "#229922",
+        "light_brown": "#d3cd69",
+        "light_blue": "#6c9ef8",
+        "light_magenta": "#b77fdb",
+        "light_cyan": "#6c9ef8",
+        "light_white": "#ffffff"
+    }
+}

--- a/themes/brackets-light.json
+++ b/themes/brackets-light.json
@@ -1,0 +1,23 @@
+{
+    "name": "Brackets Light",
+    "theme_colors": {
+        "foreground": "#535353",
+        "background": "#f8f8f8",
+        "black": "#000000",
+        "red": "#dc322f",
+        "green": "#229922",
+        "brown": "#e88501",
+        "blue": "#446fbd",
+        "magenta": "#6c71c4",
+        "cyan": "#446fbd",
+        "white": "#ffffff",
+        "light_black": "#949494",
+        "light_red": "#dd4444",
+        "light_green": "#229922",
+        "light_brown": "#e88501",
+        "light_blue": "#446fbd",
+        "light_magenta": "#8757ad",
+        "light_cyan": "#446fbd",
+        "light_white": "#ffffff"
+    }
+}

--- a/themes/campbell.json
+++ b/themes/campbell.json
@@ -1,0 +1,23 @@
+{
+    "name": "Campbell",
+    "theme_colors": {
+        "foreground": "#cccccc",
+        "background": "#0c0c0c",
+        "black": "#0c0c0c",
+        "red": "#c50f1f",
+        "green": "#13a10e",
+        "brown": "#c19c00",
+        "blue": "#0037da",
+        "magenta": "#881798",
+        "cyan": "#3a96dd",
+        "white": "#cccccc",
+        "light_black": "#767676",
+        "light_red": "#e74856",
+        "light_green": "#16c60c",
+        "light_brown": "#f9f1a5",
+        "light_blue": "#3b78ff",
+        "light_magenta": "#b4009e",
+        "light_cyan": "#61d6d6",
+        "light_white": "#f2f2f2"
+    }
+}


### PR DESCRIPTION
Add the [Campbell theme](https://github.com/microsoft/terminal/blob/62765f152e1fc9732a2ff212c9b98c1d0dbb9665/src/cascadia/TerminalApp/defaults.json#L56) from Windows Terminal and add two themes (light and dark) that go well with the [Brackets Color Schemes](https://packagecontrol.io/packages/Brackets%20Color%20Scheme).

Campbell:
![campbell](https://user-images.githubusercontent.com/6579999/72658523-74842280-39b2-11ea-8c54-5df8f8f9bec1.png)

Brackets Dark:
![brackets-dark](https://user-images.githubusercontent.com/6579999/72658518-6fbf6e80-39b2-11ea-9d68-c6f5dc57e227.png)

Brackets Light:
![brackets-light](https://user-images.githubusercontent.com/6579999/72658515-6930f700-39b2-11ea-8ec9-95b58960fa9a.png)