### PR TITLE
Add ayu mirage theme

### DIFF
--- a/themes/ayu-mirage.json
+++ b/themes/ayu-mirage.json
@@ -1,0 +1,27 @@
+{
+    "name": "ayu-mirage",
+    "theme_colors": {
+        "background": "#1f2430",
+        "foreground": "#cbccc6",
+        "caret": "#ffcc66",
+        "block_caret": "#ffcc66",
+        "selection": "#34455a",
+        "selection_foreground": "#cbccc6",
+        "black": "#1a1e29",
+        "red": "#f28779",
+        "green": "#bae67e",
+        "brown": "#ffd580",
+        "blue": "#73d0ff",
+        "magenta": "#d4bfff",
+        "cyan": "#95e6cb",
+        "white": "#c7c7c7",
+        "light_black": "#686868",
+        "light_red": "#f28779",
+        "light_green": "#bae67e",
+        "light_brown": "#ffd580",
+        "light_blue": "#73d0ff",
+        "light_magenta": "#d4bfff",
+        "light_cyan": "#95e6cb",
+        "light_white": "#ffffff"
+    }
+}

--- a/themes/ayu-mirage.json
+++ b/themes/ayu-mirage.json
@@ -1,5 +1,5 @@
 {
-    "name": "ayu-mirage",
+    "name": "Ayu Mirage",
     "theme_colors": {
         "background": "#1f2430",
         "foreground": "#cbccc6",


### PR DESCRIPTION
Add ayu mirage theme. Color extracted from:
- https://github.com/hwyncho/ayu-Terminal-app
- https://github.com/ayu-theme/ayu-colors

To comply with [ayu](https://github.com/dempfi/ayu) mirage theme.