### PR TITLE
add settings to control min and max terminal width

### DIFF
--- a/Terminus.sublime-settings
+++ b/Terminus.sublime-settings
@@ -77,6 +77,10 @@
     // decreasing this value may improve performance
     "scrollback_history_size": 10000,
 
+    // set a minimum or maximum terminal width in characters
+    "min_columns": 20,
+    "max_columns": 500,
+
     // Windows and Linux only
     // use ctrl+c to copy
     // use ctrl+v to paste  (use ctrl+alt+v to send ctrl+v instead)

--- a/terminus/core.py
+++ b/terminus/core.py
@@ -600,6 +600,14 @@ class TerminusInitializeCommand(sublime_plugin.TextCommand):
         # view_settings.set("caret_style", "blink")
         view_settings.set("scroll_past_end", True)
         view_settings.set("color_scheme", "Terminus.hidden-color-scheme")
+
+        max_columns = terminus_settings.get("max_columns")
+        if max_columns:
+            rulers = view_settings.get("rulers", [])
+            if max_columns not in rulers:
+                rulers.append(max_columns)
+                view_settings.set("rulers", rulers)
+
         # search
         if "file_regex" in kwargs:
             view_settings.set("result_file_regex", kwargs["file_regex"])

--- a/terminus/view.py
+++ b/terminus/view.py
@@ -40,9 +40,15 @@ def view_size(view):
     if pixel_per_line == 0 or pixel_per_char == 0:
         return (0, 0)
 
+    settings = sublime.load_settings("Terminus.sublime-settings")
+    min_columns = settings.get("min_columns", 20)
+    max_columns = settings.get("max_columns", 500)
+
     nb_columns = int(pixel_width / pixel_per_char) - 3
-    if nb_columns < 1:
-        nb_columns = 1
+    if nb_columns < min_columns:
+        nb_columns = min_columns
+    elif nb_columns > max_columns:
+        nb_columns = max_columns
 
     nb_rows = int(pixel_height / pixel_per_line)
     if nb_rows < 1:


### PR DESCRIPTION
Based on the discussion in #32 

I also added the `max_columns` setting that closes #81 if you find it useful. A ruler is shown at the max column.

Please let me know if you're ok with the `max_columns` and ruler bits, or if I should change anything else.

