### PR TITLE
Check for config existence

### DIFF
--- a/terminus/core.py
+++ b/terminus/core.py
@@ -130,9 +130,9 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
         else:
             config = self.get_config_by_name("Default")
 
-        if "cmd" in config:
+        if not cmd and "cmd" in config:
             cmd = config["cmd"]
-        if "shell_cmd" in config:
+        if not shell_cmd and "shell_cmd" in config:
             shell_cmd = config["shell_cmd"]
 
         if cmd and shell_cmd:
@@ -149,9 +149,6 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
                 cmd = ["/usr/bin/env", "bash", "-l", "-c", shell_cmd]
             else:
                 cmd = ["/usr/bin/env", "bash", "-c", shell_cmd]
-
-        if not cmd:
-            cmd = config["cmd"]
 
         if cmd and isinstance(cmd, str):
             cmd = [cmd]

--- a/terminus/core.py
+++ b/terminus/core.py
@@ -130,6 +130,11 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
         else:
             config = self.get_config_by_name("Default")
 
+        if "cmd" in config:
+            cmd = config["cmd"]
+        if "shell_cmd" in config:
+            shell_cmd = config["shell_cmd"]
+
         if cmd and shell_cmd:
             raise ValueError("both cmd and shell_cmd are not empty")
 


### PR DESCRIPTION
Added lines at beginning of  `run_async` to assign variables to `cmd` and `shell_cmd` if they exist in the config. In response to #248 