### PR TITLE
Make it possible to apply cwd values in shell_configs

### DIFF
--- a/terminus/core.py
+++ b/terminus/core.py
@@ -201,6 +201,9 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
 
         _env.update(env)
 
+        if "cwd" in config:
+            cwd = config["cwd"]
+
         if not cwd and working_dir:
             cwd = working_dir
 


### PR DESCRIPTION
Apply the specified `cwd` value when activating Terminus from the list of shell configs stored in `Terminus.sublime-settings`.