### PR TITLE
Add adaptive theme

### DIFF
--- a/terminus/theme.py
+++ b/terminus/theme.py
@@ -194,3 +194,4 @@ def plugin_loaded():
 def plugin_unloaded():
     settings = sublime.load_settings("Terminus.sublime-settings")
     settings_on_change(settings, ["256color", "user_theme_colors", "theme"], clear=True)
+    settings_on_change(sublime.load_settings("Preferences.sublime-settings"), "color_scheme", clear=True)

--- a/terminus/theme.py
+++ b/terminus/theme.py
@@ -82,33 +82,26 @@ class TerminusGenerateThemeCommand(sublime_plugin.WindowCommand):
                 _, _, s = rgb_to_hls(r/255, g/255, b/255)
                 if s < 0.2:
                     gray = comment_foreground
-            color_template = "color({} l(- 15%))"
-            red = color_template.format(palette["redish"])
-            green = color_template.format(palette["greenish"])
-            yellow = color_template.format(palette["yellowish"])
-            blue = color_template.format(palette["bluish"])
-            magenta = color_template.format(palette["pinkish"])
-            cyan = color_template.format(palette["cyanish"])
-            white = color_template.format(gray)
+            light_color_template = "color({} l(+ 15%))"
             variables = {
                 "background": palette["background"],
                 "foreground": palette["foreground"],
-                "black": "#000000",                  # ANSI Black
-                "red": red,                          # ANSI Red
-                "green": green,                      # ANSI Green
-                "brown": yellow,                     # ANSI Yellow
-                "blue": blue,                        # ANSI Blue
-                "magenta": magenta,                  # ANSI Magenta
-                "cyan": cyan,                        # ANSI Cyan
-                "white": white,                      # ANSI White
-                "light_black": gray,                 # ANSI Bright Black (Gray)
-                "light_red": palette["redish"],      # ANSI Bright Red
-                "light_green": palette["greenish"],  # ANSI Bright Green
-                "light_brown": palette["yellowish"], # ANSI Bright Yellow
-                "light_blue": palette["bluish"],     # ANSI Bright Blue
-                "light_magenta": palette["pinkish"], # ANSI Bright Magenta
-                "light_cyan": palette["cyanish"],    # ANSI Bright Cyan
-                "light_white": "#ffffff"             # ANSI Bright White
+                "black": "#000000",
+                "red": palette["redish"],
+                "green": palette["greenish"],
+                "brown": palette["yellowish"],
+                "blue": palette["bluish"],
+                "magenta": palette["pinkish"],
+                "cyan": palette["cyanish"],
+                "white": gray,
+                "light_black": light_color_template.format(gray),
+                "light_red": light_color_template.format(palette["redish"]),
+                "light_green": light_color_template.format(palette["greenish"]),
+                "light_brown": light_color_template.format(palette["yellowish"]),
+                "light_blue": light_color_template.format(palette["bluish"]),
+                "light_magenta": light_color_template.format(palette["pinkish"]),
+                "light_cyan": light_color_template.format(palette["cyanish"]),
+                "light_white": "#ffffff"
             }
         else:
             content = sublime.load_resource("Packages/Terminus/themes/{}.json".format(theme))

--- a/terminus/theme.py
+++ b/terminus/theme.py
@@ -190,9 +190,14 @@ def plugin_loaded():
         lambda _: sublime.active_window().run_command("terminus_generate_theme")
     )
 
-    # settings_on_change(sublime.load_settings("Preferences.sublime-settings"), "color_scheme")(
-    #     lambda _: sublime.active_window().run_command("terminus_generate_theme")
-    # )
+    def check_update_theme(value):
+        settings = sublime.load_settings("Terminus.sublime-settings")
+        if settings.get("theme", "default") == "adaptive":
+            sublime.active_window().run_command("terminus_generate_theme")
+
+    settings_on_change(sublime.load_settings("Preferences.sublime-settings"), "color_scheme")(
+        check_update_theme
+    )
 
 def plugin_unloaded():
     settings = sublime.load_settings("Terminus.sublime-settings")

--- a/terminus/theme.py
+++ b/terminus/theme.py
@@ -184,7 +184,6 @@ def plugin_loaded():
     )
 
     def check_update_theme(value):
-        settings = sublime.load_settings("Terminus.sublime-settings")
         if settings.get("theme", "default") == "adaptive":
             sublime.active_window().run_command("terminus_generate_theme")
 


### PR DESCRIPTION
This is a suggestion how to derive ANSI colors from the active color scheme on ST4.

To update the generated adaptive theme when the user has just changed their color scheme, either open the "Terminus: Select Theme" panel again, switch to another item and back to "adaptive", or uncomment the code on the bottom (that's probably not a good solution because it would also regenerate the theme on color scheme changes even if the Terminus theme is not "adaptive".

The way how to derive "light_black" from the comment foreground color is also not optimal, because it only works if there is a view opened in the active window.