### PR TITLE
Allow user to override the terminal size

### DIFF
--- a/Terminus.sublime-settings
+++ b/Terminus.sublime-settings
@@ -84,6 +84,9 @@
     "min_columns": 20,
     "max_columns": 500,
 
+    // force the terminal size
+    "size": [null, null],
+
     // Windows and Linux only
     // use ctrl+c to copy
     // use ctrl+v to paste  (use ctrl+alt+v to send ctrl+v instead)

--- a/terminus/terminal.py
+++ b/terminus/terminal.py
@@ -35,6 +35,7 @@ class Terminal:
         self._title = ""
         self.view = view
         self._cached_cursor = [0, 0]
+        self._size = sublime.load_settings('Terminus.sublime-settings').get('size', (None, None))
         self._cached_cursor_is_hidden = [True]
         self.image_count = 0
         self.images = {}
@@ -120,7 +121,7 @@ class Terminal:
 
         @responsive(period=1, default=False)
         def was_resized():
-            size = view_size(self.view)
+            size = view_size(self.view, force=self._size)
             return self.screen.lines != size[0] or self.screen.columns != size[1]
 
         def reader():
@@ -208,7 +209,7 @@ class Terminal:
             self.title = title
             self.set_offset()
 
-        size = view_size(view or sublime.active_window().active_view(), (40, 80))
+        size = view_size(view or sublime.active_window().active_view(), default=(40, 80), force=self._size)
         logger.debug("view size: {}".format(str(size)))
         _env = os.environ.copy()
         _env.update(env)
@@ -283,7 +284,7 @@ class Terminal:
         self.view.settings().set("terminus_view.closed", True)
 
     def handle_resize(self):
-        size = view_size(self.view)
+        size = view_size(self.view, force=self._size)
         logger.debug("handle resize {} {} -> {} {}".format(
             self.screen.lines, self.screen.columns, size[0], size[1]))
         try:

--- a/terminus/view.py
+++ b/terminus/view.py
@@ -32,7 +32,10 @@ def view_is_visible(view):
     return window.active_view_in_group(group) == view
 
 
-def view_size(view, default=None):
+def view_size(view, default=None, force=None):
+    if force:
+        if all(force):
+            return force
     pixel_width, pixel_height = view.viewport_extent()
     pixel_per_line = view.line_height()
     pixel_per_char = view.em_width()


### PR DESCRIPTION
When using `"word_wrap": false` in ST, it is useful to be able to override the terminal size in Terminus, so that the terminal output is not wrapped.