### PR TITLE
Add user_light_theme_colors and user_dark_theme_colors

### DIFF
--- a/terminus/theme.py
+++ b/terminus/theme.py
@@ -65,6 +65,14 @@ class TerminusGenerateThemeCommand(sublime_plugin.WindowCommand):
 
         if theme == "user":
             variables = settings.get("user_theme_colors", {})
+
+            if sublime.version() >= "4096":
+                current_style = sublime.ui_info()['theme']['style']
+                style_variables = settings.get("user_{}_theme_colors".format(current_style), None)
+
+                if isinstance(style_variables, dict):
+                    variables = dict(variables, **style_variables)
+
             for key, value in list(variables.items()):
                 if key.isdigit():
                     variables[ANSI_COLORS[int(key)]] = value
@@ -184,9 +192,9 @@ def plugin_loaded():
             lambda: sublime.active_window().run_command("terminus_generate_theme"),
             100)
 
-    settings_on_change(settings, ["256color", "user_theme_colors", "theme"])(
-        lambda _: sublime.active_window().run_command("terminus_generate_theme")
-    )
+    settings_on_change(
+        settings, ["256color", "user_theme_colors", "user_light_theme_colors", "user_dark_theme_colors", "theme"]
+    )(lambda _: sublime.active_window().run_command("terminus_generate_theme"))
 
     def check_update_theme(value):
         settings = sublime.load_settings("Terminus.sublime-settings")


### PR DESCRIPTION
This PR is a tentative step towards making Terminus aware of the current sublime theme style(light/dark) and switching between them if the sublime theme is set to `auto`(a V4 feature).

It adds support for the `user_light_theme_colors`  and `user_dark_theme_colors` settings and makes sure both are involved in the Termiuns theme generation command.

This approach is not ideal, because it cannot automatically switch the Terminus theme when Sublime switches the theme.
But at least it adds the ability to specify different theme colours and use them during the theme generation process