### PR TITLE
fix `view_settings` kwargs passing to `terminus_open` command

### DIFF
--- a/terminus/commands.py
+++ b/terminus/commands.py
@@ -46,6 +46,7 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
             pre_window_hooks=[],
             post_window_hooks=[],
             post_view_hooks=[],
+            view_settings={},
             auto_close="always",
             cancellable=False,
             reactivable=True,
@@ -227,7 +228,8 @@ class TerminusOpenCommand(sublime_plugin.WindowCommand):
                 "reactivable": reactivable,
                 "timeit": timeit,
                 "file_regex": file_regex,
-                "line_regex": line_regex
+                "line_regex": line_regex,
+                "view_settings": view_settings,
             })
 
         if show_in_panel:


### PR DESCRIPTION
This patch is a follow-up for ac3fde681102118f6b62979f5a30066600359f3a.

---

Hello @randy3k, a quick patch for #425 which contained a small oversight I apologize for : `view_settings` was missing from `TerminusOpenCommand.run_async` so `terminus_open` command is crashing with a `TypeError` when `view_settings` is specified in arguments list...

Thanks again, bye :wave: 