### PR TITLE
Make tmux work

### DIFF
--- a/terminus/ptty.py
+++ b/terminus/ptty.py
@@ -599,9 +599,12 @@ class TerminalStream(pyte.Stream):
         OSC_TERMINATORS = set([ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL, ctrl.CR])
 
         def create_dispatcher(mapping):
-            return defaultdict(lambda: debug, dict(
-                (event, getattr(listener, attr))
-                for event, attr in mapping.items()))
+            return defaultdict(
+                lambda: debug,
+                dict(
+                    (event, getattr(listener, attr)) for event, attr in mapping.items()
+                ),
+            )
 
         basic_dispatch = create_dispatcher(basic)
         sharp_dispatch = create_dispatcher(self.sharp)

--- a/terminus/ptty.py
+++ b/terminus/ptty.py
@@ -474,11 +474,11 @@ class TerminalScreen(pyte.Screen):
 
         self.cursor.attrs = self.cursor.attrs._replace(**replace)
 
-    # def report_device_attributes(self, mode=0, **kwargs):
-    #     pass
+    def report_device_attributes(self, mode=0, private=False):
+        pass
 
-    # def report_device_status(self, mode):
-    #     pass
+    def report_device_status(self, mode, private=False):
+        pass
 
     def write_process_input(self, data):
         self._process.write(data)


### PR DESCRIPTION
tmux wouldn't work:

```
  ┃    File "./python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                                                                                                                                                                        
  ┃    File "./python3.8/threading.py", line 870, in run                                                                                                                                                                                                                                                                     
  ┃    File "/home/who/.config/sublime-text/Packages/Terminus/terminus/terminal.py", line 165, in renderer                                                                                                                                                                                                                
  ┃      feed_data()                                                                                                                                                                                                                                                                                                         
  ┃    File "/home/who/.config/sublime-text/Packages/Terminus/terminus/terminal.py", line 160, in feed_data                                                                                                                                                                                                               
  ┃      self.stream.feed(data[0])                                                                                                                                                                                                                                                                                           
  ┃    File "/home/who/.config/sublime-text/Packages/Terminus/terminus/ptty.py", line 780, in feed                                                                                                                                                                                                                        
  ┃      yield_what = send(data[offset : offset + 1])                                                                                                                                                                                                                                                                        
  ┃    File "/home/who/.config/sublime-text/Packages/Terminus/terminus/ptty.py", line 736, in _parser_fsm                                                                                                                                                                                                                 
  ┃      csi_dispatch[char](*params, private=True)                                                                                                                                                                                                                                                                           
  ┃  TypeError: report_device_status() got an unexpected keyword argument 'private'       
```